### PR TITLE
browse/view refinements

### DIFF
--- a/src/app/list/page.tsx
+++ b/src/app/list/page.tsx
@@ -1,54 +1,53 @@
 import { Col, Container, Row, Table } from 'react-bootstrap';
 import { prisma } from '@/lib/prisma';
 import TemplateItem from '@/components/TemplateItem';
+import TemplateFilter from '@/components/TemplateFilter';
 import { loggedInProtectedPage } from '@/lib/page-protection';
 import { auth } from '@/lib/auth';
 
-/** Render a list of templates for the logged in user. */
+/** Render a list of templates. */
 const ListPage = async () => {
-  // Protect the page, only logged in users can access it.
   const session = await auth();
   loggedInProtectedPage(
     session as {
       user: { email: string; id: string; name: string };
     } | null,
   );
-  // const author = (session && session.user && session.user.email) || '';
-  // ^ kept this in case we want to add an edit button for the signed in user's templates
 
-  const template = await prisma.template.findMany({});
-  // console.log(template);
+  const templates = await prisma.template.findMany({
+    orderBy: { used: 'desc' },
+  });
+
+  const categories = [...new Set(templates.map(t => t.category))].filter(Boolean);
+
   return (
     <main>
-      <Container id="list-templates-page" fluid className="py-3 px-4">
+      {/* Header */}
+      <div style={{ backgroundColor: '#024731', color: '#fff' }} className="py-4">
+        <Container fluid className="px-4">
+          <div className="d-flex justify-content-between align-items-center flex-wrap gap-2">
+            <div>
+              <h1 className="fw-bold mb-1">Browse Templates</h1>
+              <p className="mb-0" style={{ opacity: 0.8, fontSize: '0.9rem' }}>
+                {templates.length} template{templates.length !== 1 ? 's' : ''} available
+              </p>
+            </div>
+            <a
+              href="/add"
+              className="btn btn-light fw-semibold"
+              style={{ color: '#024731', fontSize: '0.9rem' }}
+            >
+              + Add Template
+            </a>
+          </div>
+        </Container>
+      </div>
+
+      <Container fluid className="px-4 py-4">
         <Row>
           <Col>
-            <h2 className='mb-4 text-center'>List Templates</h2>
-            <Table
-              hover
-              responsive
-              className="w-100 overflow-auto"
-              style={{ tableLayout: 'fixed' }}
-            >
-              <thead>
-                <tr>
-                  <th className="py-3" style={{ width: '3%' }}>ID</th>
-                  <th className="py-3" style={{ width: '37%' }}>Template</th>
-                  <th className="py-3" style={{ width: '15%' }}>Category</th>
-                  <th className="py-3" style={{ width: '15%' }}>Author</th>
-                  <th className="py-3" style={{ width: '12%' }}>Used</th>
-                  <th className="py-3" style={{ width: '3%' }}></th>
-                </tr>
-              </thead>
-              <tbody>
-                {template.map((template) => (
-                  <TemplateItem
-                    key={template.id}
-                    template={template}
-                  />
-                ))}
-              </tbody>
-            </Table>
+            {/* Filter bar — client component */}
+            <TemplateFilter templates={templates} categories={categories} />
           </Col>
         </Row>
       </Container>

--- a/src/app/view/[id]/page.tsx
+++ b/src/app/view/[id]/page.tsx
@@ -23,8 +23,7 @@ export default async function ViewTemplatePage({ params }: { params: { id: strin
     },
   });
 
-  // Security: 404 if it doesn't exist or isn't the user's
-  if (!item || item.author !== session?.user?.email) {
+  if (!item) {
     return notFound();
   }
 

--- a/src/components/TemplateFilter.tsx
+++ b/src/components/TemplateFilter.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState } from 'react';
+import { Table } from 'react-bootstrap';
+import { Category, Template } from '@prisma/client';
+import TemplateItem from './TemplateItem';
+import { categoryLabels } from '@/lib/categoryLabels';
+
+type Props = {
+  templates: Template[];
+  categories: string[];
+};
+
+const TemplateFilter = ({ templates, categories }: Props) => {
+  const [activeCategory, setActiveCategory] = useState<string>('All');
+  const [search, setSearch] = useState('');
+
+  const filtered = templates.filter(t => {
+    const matchesCategory = activeCategory === 'All' || t.category === activeCategory;
+    const q = search.toLowerCase();
+    const matchesSearch = !q
+      || t.title?.toLowerCase().includes(q)
+      || t.category?.toLowerCase().includes(q)
+      || t.tags?.some(tag => tag.toLowerCase().includes(q));
+    return matchesCategory && matchesSearch;
+  });
+
+  return (
+    <>
+      {/* Search + filters */}
+      <div className="mb-4 d-flex flex-column gap-3">
+        <input
+          type="text"
+          className="form-control"
+          placeholder="Search by title, category, or tag..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          style={{ maxWidth: '420px', fontSize: '0.9rem' }}
+        />
+        <div className="d-flex flex-wrap gap-2">
+          {['All', ...categories].map(cat => (
+            <button
+              key={cat}
+              onClick={() => setActiveCategory(cat)}
+              className="btn btn-sm"
+              style={{
+                fontSize: '0.8rem',
+                backgroundColor: activeCategory === cat ? '#024731' : '#f0f0f0',
+                color: activeCategory === cat ? '#fff' : '#333',
+                border: 'none',
+                borderRadius: '20px',
+                padding: '5px 14px',
+              }}
+            >
+              {cat === 'All' ? 'All' : categoryLabels[cat as Category] ?? cat}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Table */}
+      {filtered.length > 0 ? (
+        <Table
+          hover
+          responsive
+          className="w-100"
+          style={{ tableLayout: 'fixed' }}
+        >
+          <thead>
+            <tr
+              className="text-muted"
+              style={{
+                fontSize: '0.75rem',
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                borderBottom: '2px solid #dee2e6',
+              }}
+            >
+              <th className="py-3 fw-semibold" style={{ width: '42%' }}>Template</th>
+              <th className="py-3 fw-semibold" style={{ width: '22%' }}>Category</th>
+              <th className="py-3 fw-semibold" style={{ width: '22%' }}>Author</th>
+              <th className="py-3 fw-semibold" style={{ width: '14%' }}>Used</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map(t => (
+              <TemplateItem key={t.id} template={t} />
+            ))}
+          </tbody>
+        </Table>
+      ) : (
+        <div className="text-center py-5 text-muted">
+          <p className="mb-1">No templates found.</p>
+          <p style={{ fontSize: '0.9rem' }}>
+            {search || activeCategory !== 'All'
+              ? 'Try adjusting your search or filter.'
+              : 'Be the first to add one!'}
+          </p>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default TemplateFilter;

--- a/src/components/TemplateItem.tsx
+++ b/src/components/TemplateItem.tsx
@@ -1,29 +1,58 @@
 import { Template } from '@prisma/client';
-import { ArrowRight } from 'react-bootstrap-icons';
 import Link from 'next/link';
+import { categoryLabels } from '@/lib/categoryLabels';
 
-/* Renders a single row in the List Template table. See list/page.tsx. */
+/* Renders a single row in the Browse Templates table. See list/page.tsx. */
 const TemplateItem = ({ template }: { template: Template }) => (
-  <tr id='template-item' className="align-middle">
-    {/*tagged parts to be styled later*/}
-    <td>{template.id}</td>
-    <td>
-      <div className='fs-4 fw-bold template-title overflow-auto'>{template.title}</div>
-      {template.tags?.length && (
-        <div className="mt-1 d-flex flex-wrap gap-1 overflow-auto">
+  <tr
+    className="align-middle"
+    style={{ cursor: 'pointer' }}
+    onClick={() => { window.location.href = `/view/${template.id}`; }}
+  >
+    <td style={{ maxWidth: '340px' }}>
+      <div
+        className="fw-semibold"
+        style={{
+          fontSize: '0.95rem',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+      >
+        {template.title}
+      </div>
+      {template.tags?.length > 0 && (
+        <div className="mt-1 d-flex flex-wrap gap-1">
           {template.tags.map((tag) => (
-            <span key={tag} className="badge text-bg-dark border fw-semibold template-tag">
+            <span
+              key={tag}
+              className="badge fw-normal"
+              style={{ backgroundColor: '#024731', fontSize: '0.7rem' }}
+            >
               {tag}
             </span>
           ))}
         </div>
       )}
     </td>
-    <td>{template.category}</td>
-    <td className="text-muted">{template.author}</td>
-    <td>{template.used}</td>
     <td>
-      <Link className='text-dark' href={`/view/${template.id}`}><ArrowRight /></Link>
+      <span
+        className="badge fw-normal"
+        style={{
+          backgroundColor: '#e8f0ec',
+          color: '#024731',
+          fontSize: '0.78rem',
+          padding: '5px 10px',
+        }}
+      >
+        {categoryLabels[template.category]}
+      </span>
+    </td>
+    <td className="text-muted" style={{ fontSize: '0.85rem' }}>{template.author}</td>
+    <td>
+      <span className="text-muted" style={{ fontSize: '0.85rem' }}>
+        {template.used ?? 0}×
+      </span>
     </td>
   </tr>
 );

--- a/src/components/ViewTemplate.tsx
+++ b/src/components/ViewTemplate.tsx
@@ -1,72 +1,165 @@
 'use client';
 
 import { useState } from 'react';
-import { Col, Container, Row, Card, ListGroup, Button } from 'react-bootstrap';
+import { Container, Button, Form } from 'react-bootstrap';
 import { Template } from '@prisma/client';
+import { categoryLabels } from '@/lib/categoryLabels';
+
+const MOCK_COMMENTS = [
+  { initials: 'M', name: 'Maile A.', time: '2 days ago', body: 'This one has saved me so many times during peak hours.' },
+  { initials: 'T', name: 'Tyler N.', time: '1 day ago', body: 'Heads up — double check the URL in step 3, it may have changed recently.' },
+];
 
 export default function ViewTemplate({ item }: { item: Template }) {
   const [copied, setCopied] = useState(false);
+  const [comment, setComment] = useState('');
 
   const handleCopy = async () => {
     try {
-      // Pulling the actual template body/description
-      const textToCopy = item.template || "";
-      await navigator.clipboard.writeText(textToCopy);
-      
+      await navigator.clipboard.writeText(item.template || '');
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
-      console.error('Failed to copy text: ', err);
+      console.error('Failed to copy:', err);
     }
   };
 
   return (
-    <Container className="py-5" >
-      <Row className="justify-content-center" >
-        <Col md={8}>
-          <Card className="shadow-sm">
-            <Card.Header className="text-white d-flex justify-content-between align-items-center py-3"
-            style={{ backgroundColor: '#024731'}} >
-              <h5 className="mb-0">{item.title}</h5>
-              <Button 
-                variant={copied ? "secondary" : "light"} 
-                size="sm" 
-                onClick={handleCopy}
-                className="fw-bold"
-              >
-                {copied ? "Copied!" : "Copy"}
-              </Button>
-            </Card.Header>
-            
-            <Card.Body>
-              {/* Display the actual Template Content in a readable box */}
-              <div className="p-4 bg-light border rounded mb-4">
-                <p className="text-muted small mb-2 uppercase fw-bold">Template Content:</p>
-                <pre style={{ 
-                  whiteSpace: 'pre-wrap', 
-                  marginBottom: 0,
-                  fontFamily: 'inherit',
-                  fontSize: '1.1rem' 
-                }}>
-                  {item.template}
-                </pre>
-              </div>
+    <main>
+      {/* Header */}
+      <div style={{ backgroundColor: '#024731', color: '#fff' }} className="py-4">
+        <Container>
+          <div className="text-uppercase mb-1" style={{ fontSize: '0.75rem', opacity: 0.7, letterSpacing: '0.1em' }}>
+            {categoryLabels[item.category]}
+          </div>
+          <h1 className="fw-bold mb-1" style={{ fontSize: '1.75rem' }}>{item.title}</h1>
+          <p className="mb-0" style={{ opacity: 0.75, fontSize: '0.85rem' }}>
+            By {item.author}
+          </p>
+        </Container>
+      </div>
 
-              <ListGroup variant="flush" className="small border rounded">
-                <ListGroup.Item><strong>Author:</strong> {item.author}</ListGroup.Item>
-                <ListGroup.Item><strong>Category:</strong> {item.category}</ListGroup.Item>
-                <ListGroup.Item><strong>Tags:</strong> {item.tags.join(', ')}</ListGroup.Item>
-              </ListGroup>
-              
-              <div className="mt-4">
-                <a href="/list" className="btn btn-outline-secondary">
-                  Back to List
-                </a>
+      <Container className="py-5" style={{ maxWidth: '800px' }}>
+
+        {/* Stats row */}
+        <div className="d-flex gap-4 mb-4 pb-3" style={{ borderBottom: '1px solid #dee2e6' }}>
+          <div>
+            <div className="fw-bold" style={{ fontSize: '1.4rem' }}>{item.used ?? 0}</div>
+            <div className="text-muted" style={{ fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Times Used</div>
+          </div>
+          <div>
+            <div className="fw-bold" style={{ fontSize: '1.4rem' }}>—</div>
+            <div className="text-muted" style={{ fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Copies</div>
+          </div>
+          <div>
+            <div className="fw-bold" style={{ fontSize: '1.4rem' }}>{MOCK_COMMENTS.length}</div>
+            <div className="text-muted" style={{ fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Comments</div>
+          </div>
+        </div>
+
+        {/* Email body */}
+        <div className="mb-2 d-flex justify-content-between align-items-center">
+          <span className="fw-semibold">Email Template</span>
+          <Button
+            size="sm"
+            onClick={handleCopy}
+            style={{
+              backgroundColor: copied ? '#6c757d' : '#024731',
+              border: 'none',
+              minWidth: '90px',
+            }}
+          >
+            {copied ? 'Copied!' : 'Copy'}
+          </Button>
+        </div>
+        <div
+          className="p-4 mb-4"
+          style={{
+            backgroundColor: '#f8f9fa',
+            border: '1px solid #dee2e6',
+            borderRadius: '0.375rem',
+          }}
+        >
+          <pre style={{ whiteSpace: 'pre-wrap', fontFamily: 'inherit', fontSize: '0.95rem', marginBottom: 0 }}>
+            {item.template}
+          </pre>
+        </div>
+
+        {/* Tags */}
+        {item.tags?.length > 0 && (
+          <div className="d-flex flex-wrap gap-2 mb-5">
+            {item.tags.map(tag => (
+              <span
+                key={tag}
+                className="badge fw-normal"
+                style={{ backgroundColor: '#024731', fontSize: '0.8rem' }}
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Comments */}
+        <div style={{ borderTop: '1.5px solid #212529' }} className="pt-4">
+          <h5 className="fw-bold mb-4">Comments</h5>
+
+          {MOCK_COMMENTS.map((c, i) => (
+            <div key={i} className="d-flex gap-3 mb-4">
+              <div
+                className="d-flex align-items-center justify-content-center flex-shrink-0 rounded-circle text-white fw-bold"
+                style={{ width: '38px', height: '38px', backgroundColor: '#024731', fontSize: '0.9rem' }}
+              >
+                {c.initials}
               </div>
-            </Card.Body>
-          </Card>
-        </Col>
-      </Row>
-    </Container>
+              <div>
+                <div className="d-flex gap-2 align-items-baseline mb-1">
+                  <span className="fw-semibold" style={{ fontSize: '0.9rem' }}>{c.name}</span>
+                  <span className="text-muted" style={{ fontSize: '0.78rem' }}>{c.time}</span>
+                </div>
+                <p className="mb-0" style={{ fontSize: '0.9rem' }}>{c.body}</p>
+              </div>
+            </div>
+          ))}
+
+          {/* Comment input */}
+          <div className="d-flex gap-3 mt-3">
+            <div
+              className="d-flex align-items-center justify-content-center flex-shrink-0 rounded-circle text-white fw-bold"
+              style={{ width: '38px', height: '38px', backgroundColor: '#6c757d', fontSize: '0.9rem' }}
+            >
+              ?
+            </div>
+            <div className="flex-grow-1">
+              <Form.Control
+                as="textarea"
+                rows={2}
+                placeholder="Add a comment or suggestion..."
+                value={comment}
+                onChange={e => setComment(e.target.value)}
+                style={{ fontSize: '0.9rem' }}
+              />
+              {comment.trim() && (
+                <Button
+                  size="sm"
+                  className="mt-2"
+                  style={{ backgroundColor: '#024731', border: 'none' }}
+                  onClick={() => setComment('')}
+                >
+                  Post
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Back */}
+        <div className="mt-5">
+          <a href="/list" className="text-muted" style={{ fontSize: '0.9rem' }}>
+            ← Back to Browse
+          </a>
+        </div>
+      </Container>
+    </main>
   );
 }

--- a/src/lib/categoryLabels.ts
+++ b/src/lib/categoryLabels.ts
@@ -1,0 +1,12 @@
+import { Category } from '@prisma/client';
+
+export const categoryLabels: Record<Category, string> = {
+  account: 'UH Account',
+  google_core: 'Google Core/Consumer Apps',
+  star: 'STAR/Banner',
+  duo_mobile: 'Duo Mobile/MFA',
+  lamaku: 'Lamaku/Laulima LMS',
+  network: 'Network/Printing',
+  general_support: 'General Support',
+  site_licensed_apps: 'Site License',
+};

--- a/tests/admin-pages.spec.ts
+++ b/tests/admin-pages.spec.ts
@@ -34,7 +34,7 @@ test('test access to admin page', async ({ getUserPage }) => {
   // Test Browse Templates adminPage
   await adminPage.getByRole('link', { name: 'Browse Templates' }).click();
   await expect(
-    adminPage.getByRole('heading', { name: 'Stuff' })
+    adminPage.getByRole('heading', { name: 'Browse Templates' })
   ).toBeVisible({ timeout: 5000 });
 
   // Test Admin adminPage

--- a/tests/admin-pages.spec.ts
+++ b/tests/admin-pages.spec.ts
@@ -40,7 +40,7 @@ test('test access to admin page', async ({ getUserPage }) => {
   // Test Admin adminPage
   await adminPage.getByRole('link', { name: 'Admin' }).click();
   await expect(
-    adminPage.getByRole('heading', { name: 'List Stuff Admin' })
+    adminPage.getByRole('heading', { name: 'List Templates Admin' })
   ).toBeVisible({ timeout: 5000 });
   await expect(
     adminPage.getByRole('heading', { name: 'List Users Admin' })

--- a/tests/john-pages.spec.ts
+++ b/tests/john-pages.spec.ts
@@ -27,7 +27,7 @@ test('can authenticate a specific user', async ({ getUserPage }) => {
 
   await customUserPage.getByRole('link', { name: 'Browse Templates' }).click();
   await expect(
-    customUserPage.getByRole('heading', { name: 'Stuff' })
+    customUserPage.getByRole('heading', { name: 'Browse Templates' })
   ).toBeVisible({ timeout: 5000 });
 
 });


### PR DESCRIPTION
New files added:
src/components/AddTemplateForm.tsx — new add template form (replaces AddStuffForm on the add page) src/components/TemplateFilter.tsx — new client component handling search + category filtering on the browse page src/lib/categoryLabels.ts — shared mapping from DB enum values to display names (import this anywhere you need to show a category) 

Files changed:
src/app/add/page.tsx — now uses AddTemplateForm instead of AddStuffForm src/app/list/page.tsx — redesigned with green header, delegates filtering to TemplateFilter src/components/TemplateItem.tsx — whole row is clickable, ID/arrow columns removed, categories use categoryLabels src/components/ViewTemplate.tsx — redesigned with green header, copy count, comment section mockup, now visible to all users (not just the author) src/app/view/[id]/page.tsx — removed author-only restriction, any logged-in user can view any template src/app/page.tsx — updated categories to match DB enums tests/admin-pages.spec.ts — updated heading assertions tests/john-pages.spec.ts — updated heading assertions